### PR TITLE
Add Support for mDNS

### DIFF
--- a/ampel-main/ampel-main.ino
+++ b/ampel-main/ampel-main.ino
@@ -62,6 +62,7 @@ char*                         pcHostDomain            = 0;        // Negociated 
 bool                          bHostDomainConfirmed    = false;    // Flags the confirmation of the host domain
 MDNSResponder::hMDNSService   hMDNSService            = 0;        // The handle of the service in the MDNS responder
 ESP8266WebServer              server(SERVICE_PORT);
+bool			      bGotNet = false;
 
 int x;
 int lux; // 60-200 (Luminous value of the NeoPixels)
@@ -147,14 +148,20 @@ void setup() {
     //wenn die variable sensorurl grösser 5 ist
     Serial.println("Activating WIFI");
     WiFiManager wifiManager;
-    while (WiFi.status() != WL_CONNECTED) {
+    for (int maxWait=0;maxWait<10;maxWait++) {
+      if (WiFi.status() == WL_CONNECTED) {
+	bGotNet = true;
+	break;
+      }
       delay(500);
       Serial.print(".");
     }
-    Serial.println("");
-    Serial.print("IP address: ");
-    Serial.println(WiFi.localIP());
-    setupMDNS();
+    if (bGotNet) {
+       Serial.println("");
+       Serial.print("IP address: ");
+       Serial.println(WiFi.localIP());
+       setupMDNS();
+    }
   }
 }
 
@@ -211,7 +218,7 @@ void loop() {
     checkmenu();
   }
   makeled();
-  if (gotWifiConfig) {
+  if (bGotNet) {
     loopMDNS();
   }
 }

--- a/ampel-main/ampel-main.ino
+++ b/ampel-main/ampel-main.ino
@@ -24,7 +24,6 @@
 #include <ArduinoJson.h>                    // https://github.com/bblanchon/ArduinoJson (Version 5.10.0 only)
 #include <ESP8266HTTPClient.h>
 #include <ESP8266mDNS.h>
-#include <PolledTimeout.h>
 
 // NeoPixels
 #define PIN D8       // NeoPixels pin

--- a/ampel-main/ampel-main.ino
+++ b/ampel-main/ampel-main.ino
@@ -23,6 +23,8 @@
 #include <RunningMedian.h>                  // https://github.com/RobTillaart/RunningMedian
 #include <ArduinoJson.h>                    // https://github.com/bblanchon/ArduinoJson (Version 5.10.0 only)
 #include <ESP8266HTTPClient.h>
+#include <ESP8266mDNS.h>
+#include <PolledTimeout.h>
 
 // NeoPixels
 #define PIN D8       // NeoPixels pin
@@ -34,12 +36,12 @@ SCD30 airSensor;
 
 String outputState = "off";
 char sensorurl[200] = "www.mydomain.tld/sensor.php";
+char mdnsname[200] = "my-co2ampel";
 unsigned long startMillis = 560000; //900000
 const unsigned long period = 600000;
 
 // Flag for saving data
 bool shouldSaveConfig = false;
-int sensorint;
 
 // Button menu
 int menuselect = 0;
@@ -53,6 +55,15 @@ void saveConfigCallback () {
 }
 
 
+// mDNS server
+#define SERVICE_PORT        8085    
+#define UPDATE_CYCLE        (1 * 1000)                          // every second
+
+char*                         pcHostDomain            = 0;        // Negociated host domain
+bool                          bHostDomainConfirmed    = false;    // Flags the confirmation of the host domain
+MDNSResponder::hMDNSService   hMDNSService            = 0;        // The handle of the service in the MDNS responder
+ESP8266WebServer              server(SERVICE_PORT);
+
 int x;
 int lux; // 60-200 (Luminous value of the NeoPixels)
 int co2wert;
@@ -65,6 +76,8 @@ RunningMedian licht = RunningMedian(5);
 RunningMedian co2 = RunningMedian(5);
 RunningMedian temperatur = RunningMedian(5);
 RunningMedian luftfeuchte = RunningMedian(5);
+
+bool gotWifiConfig = false;
 
 void setup() {
   Serial.begin(115200);
@@ -113,8 +126,16 @@ void setup() {
         json.printTo(Serial);
         if (json.success()) {
           Serial.println("\nparsed json");
-          strcpy(sensorurl, json["sensorurl"]);
-          sensorint = jsonBuffer.size();
+          const char* sensorurlJS = json["sensorurl"];
+          if (sensorurlJS != nullptr) {
+            gotWifiConfig = true;
+            strcpy(sensorurl, sensorurlJS);
+          }
+          const char* mdnsnameJS = json["mdnsname"];
+          if (mdnsnameJS != nullptr) {
+            gotWifiConfig = true;
+            strcpy(mdnsname, mdnsnameJS);
+          }
         } else {
           Serial.println("Failed to load JSON configuration");
         }
@@ -123,9 +144,18 @@ void setup() {
   } else {
     Serial.println("Failed to mount file system");
   }
-  if (sensorint > 5) {
+  if (gotWifiConfig) {
     //wenn die variable sensorurl grösser 5 ist
+    Serial.println("Activating WIFI");
     WiFiManager wifiManager;
+    while (WiFi.status() != WL_CONNECTED) {
+      delay(500);
+      Serial.print(".");
+    }
+    Serial.println("");
+    Serial.print("IP address: ");
+    Serial.println(WiFi.localIP());
+    setupMDNS();
   }
 }
 
@@ -182,6 +212,9 @@ void loop() {
     checkmenu();
   }
   makeled();
+  if (gotWifiConfig) {
+    loopMDNS();
+  }
 }
 
 void makewifi() {
@@ -192,23 +225,27 @@ void makewifi() {
     pixels.show();
   }
   WiFiManagerParameter custom_output("URL", "URL (kein HTTPS)", sensorurl, 200);
+  WiFiManagerParameter custom_mdnsname("MDNSNAME", "mDNS Name", mdnsname, 200);
   WiFiManager wifiManager;
   // Set configuration save notify callback
   wifiManager.setSaveConfigCallback(saveConfigCallback);
   wifiManager.addParameter(&custom_output);
+  wifiManager.addParameter(&custom_mdnsname);
   //wifiManager.resetSettings();
   wifiManager.setTimeout(120);
   wifiManager.autoConnect("co2ampel");
   Serial.println("Connected");
 
   strcpy(sensorurl, custom_output.getValue());
+  strcpy(mdnsname, custom_mdnsname.getValue());
+
   // Save the custom parameters to FS
   if (shouldSaveConfig) {
     Serial.println("Saving configuration");
     DynamicJsonBuffer jsonBuffer;
     JsonObject& json = jsonBuffer.createObject();
     json["sensorurl"] = sensorurl;
-
+    json["mdnsname"] = mdnsname;
     File configFile = SPIFFS.open("/config.json", "w");
     if (!configFile) {
       Serial.println("Failed to open config file for writing");

--- a/ampel-main/mdns.ino
+++ b/ampel-main/mdns.ino
@@ -1,0 +1,124 @@
+/*
+   setStationHostname
+*/
+bool setStationHostname(const char* p_pcHostname) {
+
+  if (p_pcHostname) {
+    WiFi.hostname(p_pcHostname);
+    Serial.printf("setDeviceHostname: Station hostname is set to '%s'\n", p_pcHostname);
+  }
+  return true;
+}
+
+
+/*
+   MDNSDynamicServiceTxtCallback
+
+   Add a dynamic MDNS TXT item 'ct' to the clock service.
+   The callback function is called every time, the TXT items for the clock service
+   are needed.
+   This can be triggered by calling MDNS.announce().
+
+*/
+/*
+void MDNSDynamicServiceTxtCallback(const MDNSResponder::hMDNSService p_hService) {
+  Serial.println("MDNSDynamicServiceTxtCallback");
+  if (hMDNSService == p_hService) {
+    Serial.print(String("Updating TXT item to: ") + co2.getMedian() + "\n");
+    MDNS.addDynamicServiceTxt(p_hService, "co2ppm",(String("")+co2.getMedian()).c_str());
+  }
+}
+*/
+
+/*
+   MDNSProbeResultCallback
+
+   Probe result callback for the host domain.
+   If the domain is free, the host domain is set and the clock service is
+   added.
+   If the domain is already used, a new name is created and the probing is
+   restarted via p_pMDNSResponder->setHostname().
+
+*/
+void hostProbeResult(String p_pcDomainName, bool p_bProbeResult) {
+
+  Serial.println("MDNSProbeResultCallback");
+  Serial.printf("MDNSProbeResultCallback: Host domain '%s.local' is %s\n", p_pcDomainName.c_str(), (p_bProbeResult ? "free" : "already USED!"));
+  if (true == p_bProbeResult) {
+    // Set station hostname
+    setStationHostname(pcHostDomain);
+    if (!bHostDomainConfirmed) {
+      // Hostname free -> setup clock service
+      bHostDomainConfirmed = true;
+      if (!hMDNSService) {
+        // Add a 'clock.tcp' service to port 'SERVICE_PORT', using the host domain as instance domain
+        hMDNSService = MDNS.addService(0, "co2ampel", "tcp", SERVICE_PORT);
+        /*
+         if (hMDNSService) {
+          // Add a simple static MDNS service TXT item
+          MDNS.addServiceTxt(hMDNSService, "tcpport", SERVICE_PORT);
+          // Set the callback function for dynamic service TXTs
+          MDNS.setDynamicServiceTxtCallback(MDNSDynamicServiceTxtCallback);
+        }
+        */
+      }
+    }
+  } else {
+    // Change hostname, use '-' as divider between base name and index
+    if (MDNSResponder::indexDomain(pcHostDomain, "-", 0)) {
+      MDNS.setHostname(pcHostDomain);
+    } else {
+      Serial.println("MDNSProbeResultCallback: FAILED to update hostname!");
+    }
+  }
+}
+
+
+/*
+   handleHTTPClient
+*/
+
+void handleHTTPRequest() {
+  Serial.println("");
+  Serial.println("HTTP Request");
+  String s;
+  s = String("{\"co2\": ") + co2.getMedian() +String(",")
+    + String("\"temperature\": ") + temperatur.getMedian() +String(",")
+    + String("\"humidity\": ") + luftfeuchte.getMedian() + String(",")
+    + String("\"brightness\": ") + licht.getMedian() + String("}\n");
+  Serial.println("Sending 200");
+  server.send(200, "application/json", s);
+}
+
+void setupMDNS() {
+   // Setup MDNS responder
+  MDNS.setHostProbeResultCallback(hostProbeResult);
+  if ((!MDNSResponder::indexDomain(pcHostDomain, 0, mdnsname)) ||
+      (!MDNS.begin(pcHostDomain))) {
+    Serial.println("Error setting up MDNS responder!");
+    return;
+  }
+  Serial.println("MDNS responder started");
+  // Setup HTTP server
+  server.on("/", handleHTTPRequest);
+  server.begin();
+  Serial.println("HTTP server started");
+}
+
+void loopMDNS() {
+// Check if a request has come in
+  server.handleClient();
+  // Allow MDNS processing
+  MDNS.update();
+  /*
+  static esp8266::polledTimeout::periodicMs timeout(UPDATE_CYCLE);
+  if (timeout.expired()) {
+
+    if (hMDNSService) {
+      // Just trigger a new MDNS announcement, this will lead to a call to
+      // 'MDNSDynamicServiceTxtCallback', which will update the time TXT item
+      MDNS.announce();
+    }
+  }
+  */
+}


### PR DESCRIPTION
With this patch, the CO2Ampel will register a _co2ampel mdns service

On a mac, run

`dns-sd -B _co2ampel._tcp`

to see which instances are around. To learn more about a particular instance, run

`dns-sd -L my-co2ampel  _co2ampel._tcp`

in this way you learn on which port you can query the ampel ... it will now return the sensor data in json form.

This PR is related to issue #26 